### PR TITLE
Quick fix to make sure the "db" file isn't empty in twweet_cli.py

### DIFF
--- a/twweet_cli.py
+++ b/twweet_cli.py
@@ -136,7 +136,7 @@ def getTweets(api):
 
 def main():
 
-    if os.path.isfile(db):
+    if os.path.isfile(db) and os.path.getsize(db) > 0:
        conn = sqlite3.connect(db)
        c=conn.cursor()
        c.execute("SELECT * FROM ApiDetails")


### PR DESCRIPTION
Just a quick change to make sure the db file is not completely empty before attempting to read from it.