### PR TITLE
Key difference between ConfigReader and setup

### DIFF
--- a/twweet_cli/config/ConfigReader.py
+++ b/twweet_cli/config/ConfigReader.py
@@ -15,8 +15,8 @@ class ConfigurationReader(object):
     def __init__(self):
         with open(yml_path + '/.twweet-cli/data/config.yml', 'r') as ymlfile:
              cfg = yaml.load(ymlfile)
-        ConfigurationReader.__tweets = cfg['tweets']
-        ConfigurationReader.__hashtag = cfg['hashtag']
+        ConfigurationReader.__tweets = cfg['Tweets']
+        ConfigurationReader.__hashtag = cfg['HashTag']
 
     @staticmethod
     def get_tweets_storage():


### PR DESCRIPTION
Fix the key names, as mentioned in this [issue](https://github.com/CruiseDevice/twweet-cli/issues/73)