### PR TITLE
Remove deprecated userstream

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+CONSUMER_KEY=placeholder
+CONSUMER_SECRET=placeholder
+ACCESS_TOKEN=placeholder
+ACCESS_TOKEN_SECRET=placeholder

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ data/
 .idea/
 
 /.vs
+
+.env

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Log in to https://apps.twitter.com/ to create a new app and generate your OAuth 
 * Access Token
 * Access Token Secret
 
+**Set Twitter OAuth credentials in ENV file**
+
+`cp .env.example .env`
+* replace `placeholder` with your relevant keys
+
 **Run the application**
 
 `$ twweet-cli`

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ import os
 import json
 import shutil
 
+from dotenv import load_dotenv
+load_dotenv()
+
 here = os.path.abspath(os.path.dirname(__file__))
 home = os.path.expanduser("~")
 
@@ -36,7 +39,7 @@ class TwtApiDetails(install):
 def check_data_dir_exists():
     try:
         original_umask = os.umask(0)
-        if os.path.exists(home+'/.twweet-cli/data'):
+        if os.path.exists(home + '/.twweet-cli/data'):
             response = input("""The data directory already exists.
                              Would you like to overwrite? [yes/no] : """)
             if response.lower() == 'yes':
@@ -50,14 +53,16 @@ def check_data_dir_exists():
 
 
 def create_creds():
-    ck = input('Enter your Consumer Key: ').strip()
-    cs = input('Enter your Consumer Secret: ').strip()
-    at = input('Enter your Access Token: ').strip()
-    ats = input('Enter your Access Token Secret: ').strip()
-    jsondata = {"consumer_key": ck,
-                "consumer_secret": cs,
-                "access_token": at,
-                "access_token_secret": ats}
+    try:
+        jsondata = {
+            "consumer_key": os.environ["CONSUMER_KEY"].strip(),
+            "consumer_secret": os.environ["CONSUMER_SECRET"].strip(),
+            "access_token": os.environ["ACCESS_TOKEN"].strip(),
+            "access_token_secret": os.environ["ACCESS_TOKEN_SECRET"].strip()
+        }
+    except Exception as e:
+        print("Make sure to set your Twitter OAuth credentials in your .env file. Refer to Readme for project setup.")
+        raise e
     with open(home + "/.twweet-cli/data/creds.json", "w") as outfile:
         json.dump(jsondata, outfile)
     os.chmod(home + '/.twweet-cli/data/creds.json', 0o777)
@@ -93,13 +98,13 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=[
         'tweepy',
-        'pyyaml'
-     ],
+        'pyyaml',
+        'python-dotenv',
+    ],
 
     entry_points={
         'console_scripts': [
             'twweet-cli = twweet_cli.main:cli',
         ],
-     },
-
+    },
 )

--- a/twweet_cli/Listener.py
+++ b/twweet_cli/Listener.py
@@ -78,15 +78,10 @@ class Listener():
                                listener=self.stream_listener_ob)
         return stream
 
-    # listen for tweets on the current user's timeline
-    def stream_your_tl(self):
-        stream = self.auth_streamer()
-        stream.userstream(_with='following', async=True)
-
     # listen for tweets containing a specific word or hashtag (a phrase might work too)
     def stream_word_or_hashtag(self, words_list):
         stream = self.auth_streamer()
-        stream.filter(track=words_list, async=True)
+        stream.filter(track=words_list, is_async=True)
 
 
 '''END STREAM'''

--- a/twweet_cli/Twweeter.py
+++ b/twweet_cli/Twweeter.py
@@ -73,7 +73,7 @@ class Twweeter():
             last = len(all_tweets)
 
         # transform the tweepy tweets into a 2D array that will populate the csv
-        out_tweets = [[tweet.id_str,tweet.created_at,tweet.text.encode("utf-8")]for tweet in all_tweets]
+        out_tweets = [[tweet.id_str, tweet.created_at, tweet.text.encode("utf-8")]for tweet in all_tweets]
 
         # write to csv
         global tweets_storage
@@ -155,7 +155,7 @@ class Twweeter():
             print("{}.{}".format(id_num, tweet["text"]))
 
     def get_creds(self):
-        if not os.path.isfile(home+'/.twweet-cli/data/creds.json'):
+        if not os.path.isfile(home + '/.twweet-cli/data/creds.json'):
             self.create_creds()
         with open(home + '/.twweet-cli/data/creds.json') as json_file:
             return json.load(json_file)
@@ -171,7 +171,7 @@ class Twweeter():
                         "access_token": at,
                         "access_token_secret": ats}
 
-            with open(home+"/.twweet-cli/data/creds.json", "w") as outfile:
+            with open(home + "/.twweet-cli/data/creds.json", "w") as outfile:
                 json.dump(jsondata, outfile)
 
         except KeyError:

--- a/twweet_cli/config/ConfigReader.py
+++ b/twweet_cli/config/ConfigReader.py
@@ -6,15 +6,17 @@ Created on Thu Aug 17 01:26:52 2017
 import yaml
 from os.path import expanduser
 
-##to do
+# TODO: implement singleton pattern here
 yml_path = expanduser("~")
-#implement singleton pattern here
+
+
 class ConfigurationReader(object):
     __tweets = None
     __hashtag = None
+
     def __init__(self):
         with open(yml_path + '/.twweet-cli/data/config.yml', 'r') as ymlfile:
-             cfg = yaml.load(ymlfile)
+            cfg = yaml.load(ymlfile)
         ConfigurationReader.__tweets = cfg['Tweets']
         ConfigurationReader.__hashtag = cfg['HashTag']
 

--- a/twweet_cli/main.py
+++ b/twweet_cli/main.py
@@ -36,14 +36,14 @@ class TwweetCLI():
 
     def home_select_action(self):
 
-        option = input(
-            '''1. Get tweets of any user
+        option = input('''
+            1. Get tweets of any user
             2. Get tweets of particular hashtag
             3. Get trending topics
-            4. Read your timeline
-            5. Get your followers list
-            6. Get your tweets
-            Press 99 to exit or press 66 to go back to main menu :: ''')
+            4. Get your followers list
+            5. Get your tweets
+            Press 99 to exit or press 66 to go back to main menu ::
+        ''')
         if option == '99':
             sys.exit(0)
         if option == '66':
@@ -58,13 +58,8 @@ class TwweetCLI():
         elif option == '3':
             self.twweeter_obj.get_trending_topics()
         elif option == '4':
-            print(('\nStreaming twweets from your Timeline...'))
-            self.listener_obj.stream_your_tl()
-            return False
-            # read_timeline(api)
-        elif option == '5':
             self.twweeter_obj.get_followers_list()
-        elif option == '6':
+        elif option == '5':
             self.twweeter_obj.get_tweets()
         else:
             print(('Please choose any of the above options\n \n'))
@@ -73,19 +68,19 @@ class TwweetCLI():
         self.twweeter_obj = Twweeter()
         self.listener_obj = Listener(self.twweeter_obj)
         self.check_data_dir_exists()
-        print(""" 
+        print("""
 _____________      __  __      ___________________________________
 \__    ___/  \    /  \/  \    /  \_   _____/\_   _____/\__    ___/
   |    |  \   \/\/   /\   \/\/   /|    __)_  |    __)_   |    |     ______ 
   |    |   \        /  \        / |        \ |        \  |    |    /_____/ 
   |____|    \__/\  /    \__/\  / /_______  //_______  /  |____| 
                  \/          \/          \/         \/ 
-_________ .____    .___ 
-\_   ___ \|    |   |   | 
-/    \  \/|    |   |   | 
-\     \___|    |___|   | 
- \______  /_______ \___| 
-        \/        \/ 
+_________ .____    .___
+\_   ___ \|    |   |   |
+/    \  \/|    |   |   |
+\     \___|    |___|   |
+ \______  /_______ \___|
+        \/        \/
         """)
         print('Press 99 to quit the application')
         while True:


### PR DESCRIPTION
Unfortunately `userstream` is no longer available by api. And would return status code `410`.
https://github.com/tweepy/tweepy/issues/1092

According to Twitter's API docs:
`410 | Gone | This resource is gone. Used to indicate that an API endpoint has been turned off.`

This PR removes the option from `twweet-cli`.

I also was running into problems running `twweet-cli` with python 3.7. Because async is a `reserved` word. This was fixed in `tweepy` but hasn't been released yet. Please let me know what your thoughts are on this.

https://github.com/tweepy/tweepy/pull/1042