### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+setuptools==39.1.0
+tweepy==3.6.0
+python-dotenv==0.9.1
+PyYAML==3.13


### PR DESCRIPTION
When going through the installation process I noticed that the necessary package dependencies aren't being installed via the `python setup.py install` command. In which case, it's usually best practice to include a [requirements.txt](https://pip.pypa.io/en/stable/user_guide/#requirements-files) file so that all necessary dependencies can be easily installed with `pip install -r requirements.txt`.